### PR TITLE
Fixed 'None' and 'NoReturn' bug in inferring router.

### DIFF
--- a/fastapi_utils/inferring_router.py
+++ b/fastapi_utils/inferring_router.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Callable, get_type_hints
+from typing import TYPE_CHECKING, Any, Callable, NoReturn, get_type_hints
 
 from fastapi import APIRouter
 
@@ -12,5 +12,7 @@ class InferringRouter(APIRouter):
 
         def add_api_route(self, path: str, endpoint: Callable[..., Any], **kwargs: Any) -> None:
             if kwargs.get("response_model") is None:
-                kwargs["response_model"] = get_type_hints(endpoint).get("return")
+                return_hint = get_type_hints(endpoint).get("return")
+                if return_hint not in (type(None), NoReturn):  # noqa: E721
+                    kwargs["response_model"] = return_hint
             return super().add_api_route(path, endpoint, **kwargs)

--- a/tests/test_inferring_router.py
+++ b/tests/test_inferring_router.py
@@ -1,3 +1,5 @@
+from typing import NoReturn
+
 from fastapi import FastAPI
 
 from fastapi_utils.inferring_router import InferringRouter
@@ -34,6 +36,24 @@ openapi_spec = {
                 "summary": "Endpoint 2",
             }
         },
+        "/3": {
+            "get": {
+                "operationId": "endpoint_3_3_get",
+                "responses": {
+                    "200": {"content": {"application/json": {"schema": {}}}, "description": "Successful " "Response"}
+                },
+                "summary": "Endpoint 3",
+            }
+        },
+        "/4": {
+            "get": {
+                "operationId": "endpoint_4_4_get",
+                "responses": {
+                    "200": {"content": {"application/json": {"schema": {}}}, "description": "Successful " "Response"}
+                },
+                "summary": "Endpoint 4",
+            }
+        },
     },
 }
 
@@ -48,6 +68,14 @@ def test_inferring_router() -> None:
     @inferring_router.get("/2", response_model=int)
     def endpoint_2() -> str:  # pragma: no cover
         return ""
+
+    @inferring_router.get("/3")
+    def endpoint_3() -> None:  # pragma: no cover
+        pass
+
+    @inferring_router.get("/4")
+    def endpoint_4() -> NoReturn:  # pragma: no cover
+        pass
 
     app = FastAPI()
     app.include_router(inferring_router)


### PR DESCRIPTION
Fixes #172.

Note that the comparison must be done using `type` since `None` is a special typehint case. Python documentation states: 

> Note that `None` as a type hint is a special case and is replaced by `type(None)`."

Referenced [here](https://docs.python.org/3/library/typing.html#type-aliases).