### PR TITLE
Enable SQLAlchemy Caching for GUID type

### DIFF
--- a/fastapi_utils/guid_type.py
+++ b/fastapi_utils/guid_type.py
@@ -27,6 +27,7 @@ class GUID(UUIDTypeDecorator):
     """
 
     impl = CHAR
+    cache_ok = True
 
     @no_type_check
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Enables SQL Alchemy to cache the custom type. See https://docs.sqlalchemy.org/en/14/core/custom_types.html for more information.