### PR TITLE
Don't infer `response_model` for invalid types

### DIFF
--- a/fastapi_utils/inferring_router.py
+++ b/fastapi_utils/inferring_router.py
@@ -1,5 +1,7 @@
-from typing import TYPE_CHECKING, Any, Callable, get_type_hints
+from typing import Any, Callable, get_type_hints
 
+import fastapi.exceptions
+import fastapi.utils
 from fastapi import APIRouter
 
 
@@ -8,9 +10,15 @@ class InferringRouter(APIRouter):
     Overrides the route decorator logic to use the annotated return type as the `response_model` if unspecified.
     """
 
-    if not TYPE_CHECKING:  # pragma: no branch
-
-        def add_api_route(self, path: str, endpoint: Callable[..., Any], **kwargs: Any) -> None:
-            if kwargs.get("response_model") is None:
-                kwargs["response_model"] = get_type_hints(endpoint).get("return")
-            return super().add_api_route(path, endpoint, **kwargs)
+    def add_api_route(self, path: str, endpoint: Callable[..., Any], **kwargs: Any) -> None:
+        if kwargs.get("response_model") is None:
+            return_annotation = get_type_hints(endpoint).get("return")
+            if return_annotation is not None:
+                try:
+                    fastapi.utils.create_response_field("", return_annotation)
+                except fastapi.exceptions.FastAPIError:
+                    # The return type is not a valid `response_model`
+                    pass
+                else:
+                    kwargs["response_model"] = return_annotation
+        return super().add_api_route(path, endpoint, **kwargs)

--- a/tests/test_inferring_router.py
+++ b/tests/test_inferring_router.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 
 from fastapi_utils.inferring_router import InferringRouter
 
@@ -34,6 +34,24 @@ openapi_spec = {
                 "summary": "Endpoint 2",
             }
         },
+        "/3": {
+            "get": {
+                "operationId": "endpoint_3_3_get",
+                "responses": {
+                    "200": {"content": {"application/json": {"schema": {}}}, "description": "Successful " "Response"}
+                },
+                "summary": "Endpoint 3",
+            }
+        },
+        "/4": {
+            "get": {
+                "operationId": "endpoint_4_4_get",
+                "responses": {
+                    "200": {"content": {"application/json": {"schema": {}}}, "description": "Successful " "Response"}
+                },
+                "summary": "Endpoint 4",
+            }
+        },
     },
 }
 
@@ -47,6 +65,14 @@ def test_inferring_router() -> None:
 
     @inferring_router.get("/2", response_model=int)
     def endpoint_2() -> str:  # pragma: no cover
+        return ""
+
+    @inferring_router.get("/3")
+    def endpoint_3() -> Response:  # pragma: no cover
+        return Response(b"")
+
+    @inferring_router.get("/4")
+    def endpoint_4():  # pragma: no cover
         return ""
 
     app = FastAPI()


### PR DESCRIPTION
It is possible for `inferring_router` to raise an exception if a function uses a return type that is not a valid `response_model`. An example is an endpoint that returns `Response` instead of letting FastAPI construct one.

This PR fixes that by only inferring the `response_model` if the return annotation is a valid `response_model`.

Fixes #229 
Fixes #172