### PR TITLE
fix(tasks): Fix @repeat_every blocking app startup

### DIFF
--- a/fastapi_utils/tasks.py
+++ b/fastapi_utils/tasks.py
@@ -74,7 +74,7 @@ def repeat_every(
                     repetitions += 1
                     await asyncio.sleep(seconds)
 
-            await asyncio.ensure_future(loop())
+            asyncio.ensure_future(loop())
 
         return wrapped
 

--- a/fastapi_utils/tasks.py
+++ b/fastapi_utils/tasks.py
@@ -74,7 +74,7 @@ def repeat_every(
                     repetitions += 1
                     await asyncio.sleep(seconds)
 
-            await loop()
+            asyncio.ensure_future(loop())
 
         return wrapped
 

--- a/fastapi_utils/tasks.py
+++ b/fastapi_utils/tasks.py
@@ -74,7 +74,7 @@ def repeat_every(
                     repetitions += 1
                     await asyncio.sleep(seconds)
 
-            asyncio.ensure_future(loop())
+            await asyncio.ensure_future(loop())
 
         return wrapped
 


### PR DESCRIPTION
# Description of the bug
A function using `@repeat_every` blocks app startup on version 0.6.0 when it is called in the context manager.
This should fix #305.

# Description of the changes
Replacing (https://github.com/dmontagu/fastapi-utils/blob/master/fastapi_utils/tasks.py#L77) with `asyncio.ensure_future(loop())` works.
Every test passes for me.
